### PR TITLE
Fix sign-up redirect and fetch error handling

### DIFF
--- a/src/Components/common/Game.jsx
+++ b/src/Components/common/Game.jsx
@@ -56,7 +56,7 @@ export default function Game() {
         fetch(urlGet)
             .then(res => res.json())
             .then(data => setTextList(data))
-            .catch(setTextList([]));
+            .catch(() => setTextList([]));
     }, []);
 
     const handleSelectChange = (e) => {

--- a/src/Components/common/SignUp.jsx
+++ b/src/Components/common/SignUp.jsx
@@ -41,7 +41,7 @@ export default function SignUp() {
                             "Content-Type": "application/json",
                         },
                         body: JSON.stringify(insertValue),
-                    }).then(res => res.json()).then(nav("/login")).catch(err => console.log(err));
+                    }).then(res => res.json()).then(() => nav("/login")).catch(err => console.log(err));
                 } else {
                     setErr("User name already been used!")
                 }


### PR DESCRIPTION
## Summary
- Ensure sign-up navigates after successful registration
- Properly handle fetch errors when retrieving game text

## Testing
- `npm test` *(fails: Cannot find module './Components/common/Header' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_6896c57677d48320bcb40addcdcd93c9